### PR TITLE
Feat: output channel identifier in resp id

### DIFF
--- a/free_one_api/impls/forward/mgr.py
+++ b/free_one_api/impls/forward/mgr.py
@@ -71,7 +71,12 @@ class ForwardManager(forwardmgr.AbsForwardManager):
         req: request.Request,
     ) -> quart.Response:
         before = time.time()
-        id_suffix = "".join(random.choices(string.ascii_letters+string.digits, k=29))
+        
+        # id_suffix: channel id(3 chars) + adapter module name(max 10 chars) + random(16 chars)
+        id_suffix = ""
+        id_suffix += "{}".format(chan.id).zfill(3)
+        id_suffix += chan.adapter.__class__.__name__[:10]
+        id_suffix += "".join(random.choices(string.ascii_letters+string.digits, k=29-len(id_suffix)))
         
         normal_message = ""
         


### PR DESCRIPTION
Response data shows the channel info now:

- `002`: the id of used channel  
- `RevChatGPT`: class name of the adapter of the used channel 

```json
{
  "id": "chatcmpl-002RevChatGPTEZBkaZ9eBWuIQgBP",
   ...
}
```
