### PR TITLE
Fix(revChatGPT): duplicated context in response

### DIFF
--- a/docs/en/Adapters.md
+++ b/docs/en/Adapters.md
@@ -32,10 +32,12 @@ ChatGPT official website reverse engineering library
 
 ChatGPT needs to use a reverse proxy to bypass Cloudflare's restrictions. The Free One API project defaults to the proxy address provided by the developer `https://chatproxy.rockchin.top/api/`, but the pressure is very high. It is strongly recommended to build a reverse proxy by yourself.
 
-* Please configure according to this project document: <https://github.com/acheong08/ChatGPT-Proxy-V4>
+* You can build it using the following projects, if they are all unavailable, please find other reverse proxies by yourself:
+  - https://github.com/flyingpot/chatgpt-proxy (Recommended)
+  - https://github.com/acheong08/ChatGPT-Proxy-V4 (Unavailable)
 
-Edit `misc.chatgpt_api_base` to your reverse proxy address in `data/config.yaml`.
-You can also enter directly in the `Config` column when creating the `acheong08/ChatGPT` adapter
+Modify `adapters.acheong08_ChatGPT.reverse_proxy` to your reverse proxy address in `data/config.yaml`.
+You can also directly enter in the `Config` column when creating the `acheong08/ChatGPT` adapter
 
 ```json
 {
@@ -43,7 +45,10 @@ You can also enter directly in the `Config` column when creating the `acheong08/
 }
 ```
 
-If not set, the `misc.chatgpt_api_base` field in the configuration file will be used as the reverse proxy address.
+Set the reverse proxy address used by this adapter.
+
+> **WARNING**  
+> The current reverse proxy may have [the situation of repeating the previous text](https://github.com/RockChinQ/free-one-api/issues/75)(CN), `free-one-api` will automatically delete duplicate content. If unexpected situations occur, please set `adapters.acheong08_ChatGPT.auto_ignore_duplicated` to `false` to disable this feature.
 
 ## KoushikNavuluri/Claude-API
 

--- a/docs/en/Config.md
+++ b/docs/en/Config.md
@@ -3,17 +3,22 @@
 Configuration file is saved at `data/config.yaml`
 
 ```yaml
+# Global configuration for each adapter
+adapters:
+  acheong08_ChatGPT:
+    # Whether to auto ignore duplicated response. see: https://github.com/RockChinQ/free-one-api/issues/75
+    auto_ignore_duplicated: false
+    # Reverse proxy address for acheong08/ChatGPT adapter.
+    # Default public reverse proxy may be unstable, it is recommended to build your own:
+    # https://github.com/flyingpot/chatgpt-proxy (Recommended)
+    # https://github.com/acheong08/ChatGPT-Proxy-V4 (Unavailable)
+    reverse_proxy: https://chatproxy.rockchin.top/api/
 database:
   # SQLite DB file path
   path: ./data/free_one_api.db
   type: sqlite
 logging:
   debug: false  # Enable debug log
-misc:
-  # Reverse proxy address for acheong08/ChatGPT adapter.
-  # Default public reverse proxy may be unstable, it is recommended to build your own:
-  # https://github.com/acheong08/ChatGPT-Proxy-V4
-  chatgpt_api_base: https://chatproxy.rockchin.top/api/
 # Random advertisement, will be appended to the end of each response
 random_ad:
   # advertisement list

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,5 +1,8 @@
 # Free One API Documentation
 
+> **NOTE**  
+> Some of the content in this document is translated by GPT (GitHub Copilot).
+
 ## Supported LLM libs
 
 |Adapter|Multi Round|Stream|Function Call|Status|Comment|

--- a/docs/zh-CN/Adapters.md
+++ b/docs/zh-CN/Adapters.md
@@ -32,9 +32,11 @@ ChatGPT 官网逆向工程库
 
 ChatGPT 需要通过反向代理才能绕过 Cloudflare 的限制，Free One API 项目默认使用开发者提供的代理地址 `https://chatproxy.rockchin.top/api/` ，但压力很大，强烈建议自行搭建反向代理。
 
-* 请根据此项目文档配置：<https://github.com/acheong08/ChatGPT-Proxy-V4>
+* 可以根据以下项目搭建，若均不可用，请自行寻找其他反代:
+  - https://github.com/flyingpot/chatgpt-proxy （推荐）
+  - https://github.com/acheong08/ChatGPT-Proxy-V4 （不可用）
 
-在`data/config.yaml`中修改`misc.chatgpt_api_base`为你的反向代理地址即可。
+在`data/config.yaml`中修改`adapters.acheong08_ChatGPT.reverse_proxy`为你的反向代理地址即可。
 也可以在创建 `acheong08/ChatGPT` 适配器时，直接在 `Config` 栏中输入
 
 ```json
@@ -44,7 +46,9 @@ ChatGPT 需要通过反向代理才能绕过 Cloudflare 的限制，Free One API
 ```
 
 设置此适配器使用的反向代理地址。
-若未设置，将使用配置文件中的 `misc.chatgpt_api_base` 字段作为反向代理地址。
+
+> **WARNING**  
+> 目前使用的反代可能存在[重复回复前文的情况](https://github.com/RockChinQ/free-one-api/issues/75)，`free-one-api` 会自动删除重复内容，若出现意想不到的情况，请设置`adapters.acheong08_ChatGPT.auto_ignore_duplicated`为`false` 以禁用此功能。
 
 ## KoushikNavuluri/Claude-API
 

--- a/docs/zh-CN/Config.md
+++ b/docs/zh-CN/Config.md
@@ -3,17 +3,22 @@
 配置文件位于`data/config.yaml`
 
 ```yaml
+# 每个适配器的全局配置
+adapters:
+  acheong08_ChatGPT:
+    # 是否自动忽略重复的响应 see: https://github.com/RockChinQ/free-one-api/issues/75
+    auto_ignore_duplicated: false
+    # acheong08/ChatGPT 适配器的反向代理地址
+    # 默认的公共反代可能不稳定，建议自行搭建，若下方项目均不可用，请自行寻找其他反代:
+    # https://github.com/flyingpot/chatgpt-proxy （推荐）
+    # https://github.com/acheong08/ChatGPT-Proxy-V4 （不可用）
+    reverse_proxy: https://chatproxy.rockchin.top/api/
 database:
   # SQLite 数据库文件路径
   path: ./data/free_one_api.db
   type: sqlite
 logging:
   debug: false  # 是否开启调试日志
-misc:
-  # acheong08/ChatGPT 适配器的反向代理路径
-  # 默认的公共反代可能不稳定，建议自行搭建:
-  # https://github.com/acheong08/ChatGPT-Proxy-V4
-  chatgpt_api_base: https://chatproxy.rockchin.top/api/
 # 随机广告
 # 会随机追加到每个响应的末尾
 random_ad:

--- a/free_one_api/impls/adapter/revChatGPT.py
+++ b/free_one_api/impls/adapter/revChatGPT.py
@@ -102,6 +102,7 @@ Please refer to https://github.com/acheong08/ChatGPT
         config_copy = config.copy()
 
         reverse_proxy = RevChatGPTAdapter.reverse_proxy
+        auto_ignore_duplicated = RevChatGPTAdapter.auto_ignore_duplicated
         
         if 'reverse_proxy' in config_copy:
             reverse_proxy = config_copy['reverse_proxy']
@@ -109,8 +110,13 @@ Please refer to https://github.com/acheong08/ChatGPT
             # delete reverse_proxy from config
             del config_copy['reverse_proxy']
             
+        if 'auto_ignore_duplicated' in config_copy:
+            self.auto_ignore_duplicated = config_copy['auto_ignore_duplicated']
+            del config_copy['auto_ignore_duplicated']
+
         self.cfg = config_copy
         self.reverse_proxy = reverse_proxy
+        self.auto_ignore_duplicated = auto_ignore_duplicated
     
     async def test(self) -> (bool, str):
         conversation_id = ""
@@ -172,8 +178,10 @@ Please refer to https://github.com/acheong08/ChatGPT
                 # skip if:
                 # 1. more than two spaces contained in the message
                 # and 2. message in any elements of the assistant messages
+                # and 3. auto_ignore_duplicated is True
                 if message.count(" ") >= 2 and \
-                    any([message in msg for msg in assistant_messages]):
+                    any([message in msg for msg in assistant_messages]) and \
+                    self.auto_ignore_duplicated:
                     continue
 
                 yield response.Response(

--- a/free_one_api/impls/adapter/revChatGPT.py
+++ b/free_one_api/impls/adapter/revChatGPT.py
@@ -15,8 +15,6 @@ from ...models.channel import evaluation
 @adapter.llm_adapter
 class RevChatGPTAdapter(llm.LLMLibAdapter):
     
-    CHATGPT_API_BASE = "https://chatproxy.rockchin.top/api/"
-    
     @classmethod
     def name(cls) -> str:
         return "acheong08/ChatGPT"
@@ -83,8 +81,9 @@ Please refer to https://github.com/acheong08/ChatGPT
         return "/v1/chat/completions"
     
     cfg: dict = None
-    reverse_proxy: str = None
-    
+    reverse_proxy: str = "https://chatproxy.rockchin.top/api/"
+    auto_ignore_duplicated: bool = True
+
     _chatbot: chatgpt.AsyncChatbot = None
     
     @property
@@ -100,9 +99,9 @@ Please refer to https://github.com/acheong08/ChatGPT
         self.config = config
         self.eval = eval
         
-        reverse_proxy = RevChatGPTAdapter.CHATGPT_API_BASE
-        
         config_copy = config.copy()
+
+        reverse_proxy = RevChatGPTAdapter.reverse_proxy
         
         if 'reverse_proxy' in config_copy:
             reverse_proxy = config_copy['reverse_proxy']

--- a/free_one_api/impls/adapter/revChatGPT.py
+++ b/free_one_api/impls/adapter/revChatGPT.py
@@ -138,7 +138,13 @@ Please refer to https://github.com/acheong08/ChatGPT
 
     async def query(self, req: request.Request) -> typing.AsyncGenerator[response.Response, None]:        
         new_messages = []
+
+        assistant_messages: list[str] = []
+
         for i in range(len(req.messages)):
+            if req.messages[i]['role'] == "assistant":
+                assistant_messages.append(req.messages[i]['content'])
+
             new_messages.append({
                 "id": str(uuid.uuid4()),
                 "author": {"role": req.messages[i]['role']},
@@ -164,6 +170,13 @@ Please refer to https://github.com/acheong08/ChatGPT
                 prev_text = data["message"]
                 conversation_id = data["conversation_id"]
                 
+                # skip if:
+                # 1. more than two spaces contained in the message
+                # and 2. message in any elements of the assistant messages
+                if message.count(" ") >= 2 and \
+                    any([message in msg for msg in assistant_messages]):
+                    continue
+
                 yield response.Response(
                     id=random_int,
                     finish_reason=response.FinishReason.NULL,

--- a/free_one_api/impls/forward/mgr.py
+++ b/free_one_api/impls/forward/mgr.py
@@ -58,6 +58,8 @@ class ForwardManager(forwardmgr.AbsForwardManager):
                         continue
                     
                     record.resp_message_length += len(resp.normal_message)
+
+                    logging.debug("resp: {}".format(resp))
                     
                     yield "data: {}\n\n".format(json.dumps({
                         "id": "chatcmpl-"+resp_id,
@@ -173,6 +175,9 @@ class ForwardManager(forwardmgr.AbsForwardManager):
                     resp_tmp = resp
                     normal_message += resp.normal_message
                     record.resp_message_length += len(resp.normal_message)
+            
+            logging.debug("resp: {}".format(resp))
+            logging.debug("normal_message: {}".format(normal_message))
 
             if randomad.enabled:
                 for word in randomad.generate_ad():

--- a/free_one_api/impls/forward/mgr.py
+++ b/free_one_api/impls/forward/mgr.py
@@ -171,13 +171,12 @@ class ForwardManager(forwardmgr.AbsForwardManager):
                 if record.latency < 0:
                     record.latency = time.time() - before
 
+                logging.debug("resp: {}".format(resp))
+
                 if resp.normal_message is not None:
                     resp_tmp = resp
                     normal_message += resp.normal_message
                     record.resp_message_length += len(resp.normal_message)
-            
-            logging.debug("resp: {}".format(resp))
-            logging.debug("normal_message: {}".format(normal_message))
 
             if randomad.enabled:
                 for word in randomad.generate_ad():


### PR DESCRIPTION
fix: 
- #75 Response contains the history msgs while querying revChatGPT with history msgs

feat:

- Add section `adapters` in config file
  - Deprecate `misc` section and move `chatgpt_api_base` to `adapters.acheong08_ChatGPT` as `reverse_proxy`